### PR TITLE
fixed broken dependency

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,4 +1,4 @@
 ---
-win_apache::conffile: "c:\tools\apache24\conf\httpd.conf" #change to reflect <path-to-conf-file>
+win_apache::conffile: "c:\\tools\\apache24\\conf\\httpd.conf' #change to reflect <path-to-conf-file>
 win_apache::apache_version: 'installed' #use installed, absent for uninstalled, or version number
 win_apache::install_location: 'c:\\tools' #The installer will still install to "\Apache24"

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,4 +1,4 @@
 ---
-win_apache::conffile: "c:\\tools\\apache24\\conf\\httpd.conf' #change to reflect <path-to-conf-file>
+win_apache::conffile: "c:\\tools\\apache24\\conf\\httpd.conf" #change to reflect <path-to-conf-file>
 win_apache::apache_version: 'installed' #use installed, absent for uninstalled, or version number
 win_apache::install_location: 'c:\\tools' #The installer will still install to "\Apache24"

--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
       "name": "puppetlabs-stdlib",
       "version_requirement": ">= 4.13.1 < 5.0.0",
       "name": "puppetlabs-chocolatey",
-      "version_requirement": ">=3.0.0 < 3.0.0"
+      "version_requirement": ">=3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Puppet 4.10 reports "Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, undefined method `include?' for nil:NilClass at /etc/puppetlabs/code/environments/production/modules/win_apache/manifests/init.pp:15:3 on node X"

In this ticket it is mentioned that the dependency for puppetlabs-chocolatey is broken as listed here. So I removed the restriction to versions smaller 3.0.0 as it seems unnecessary.
https://tickets.puppetlabs.com/browse/PUP-8031